### PR TITLE
Client.headers() now returns a dict, with the key being the response header and the value being a list of response values.

### DIFF
--- a/webkit_server.py
+++ b/webkit_server.py
@@ -255,13 +255,21 @@ class Client(SelectionMixin):
     return int(self.conn.issue_command("Status"))
 
   def headers(self):
-    """ Returns a list of the last HTTP response headers. """
+    """ Returns a dict of the last HTTP response headers.
+
+    The key is the response header and the value is a list of response values.
+    """
     headers = self.conn.issue_command("Headers")
-    res = []
+    res = {}
     for header in headers.split("\r"):
-      key, value = header.split(": ", 1)
-      for line in value.split("\n"):
-        res.append((key, line))
+        key, value = header.split(": ", 1)
+        response_values = []
+
+        for line in value.split("\n"):
+            response_values.append(line)
+
+        res[key] = response_values
+
     return res
 
   def eval_script(self, expr):


### PR DESCRIPTION
You changed the Client.headers() method today in response to my bug report.

You changed it to return a list of tupples (originally returns a dict of strings). I think it might be better to continue returning a dict, as users generally want to isolate specific headers. I rewrote it so that it returns a dict, with the value being a list. I think it is easier for the user to deal with accessing list values than iterating over the list, testing for the equality of the first element to their desired response header.

