### PR TITLE
Encode the issue_command args before setting their length.

### DIFF
--- a/webkit_server.py
+++ b/webkit_server.py
@@ -513,9 +513,9 @@ class ServerConnection(object):
     self._writeline(cmd)
     self._writeline(str(len(args)))
     for arg in args:
-      arg = str(arg)
+      arg = str(arg).encode("utf-8")
       self._writeline(str(len(arg)))
-      self._sock.sendall(arg.encode("utf-8"))
+      self._sock.sendall(arg)
 
     return self._read_response()
 


### PR DESCRIPTION
Fixes #30

See my comments in #30 for more info about this.

Perhaps a unit test that should be set up:

```
import dryscrape
import sys

if 'linux' in sys.platform:
    # start xvfb in case no X is running. Make sure xvfb 
    # is installed, otherwise this won't work!
    dryscrape.start_xvfb()

search_term = '西安 some non-latin characters 北京'

# set up a web scraping session
sess = dryscrape.Session(base_url = 'http://google.com')

# we don't need images
sess.set_attribute('auto_load_images', False)

# visit homepage and search for a term
sess.visit('/')
q = sess.at_xpath('//*[@name="q"]')
q.set(search_term)
// issue another command to the driver, to make sure the above command worked successfully (len was set properly)
q = sess.at_xpath("//*[@name="btnK"]')
q.click()

# extract all links
for link in sess.xpath('//a[@href]'):
  print(link['href'])

# save a screenshot of the web page
sess.render('google.png')
print("Screenshot written to 'google.png'")
```