### PR TITLE
Use communicate() to ensure standard file descriptors are closed

### DIFF
--- a/webkit_server.py
+++ b/webkit_server.py
@@ -432,7 +432,7 @@ class Server(object):
   def kill(self):
     """ Kill the process. """
     self._server.kill()
-    self._server.wait()
+    self._server.communicate()
 
   def connect(self):
     """ Returns a new socket connection to this server. """


### PR DESCRIPTION
This internally calls `wait()` but also ensures that any file descriptors for `stdin`, `stdout`, and `stderr` are closed. If we don't do this we'll leak file descriptors. For long running processes that start & stop a WebKit
server many times this can result in an eventual crash due to hitting the max open files limit on the underlying system.